### PR TITLE
Use openjpeg and libheif modules from runtime

### DIFF
--- a/org.tropy.Tropy.yml
+++ b/org.tropy.Tropy.yml
@@ -43,18 +43,6 @@ cleanup:
   - /share/pkgconfig
 
 modules:
-  - name: openjpeg
-    builddir: true
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DBUILD_CODEC=OFF
-    cleanup:
-      - /bin
-      - /lib/openjpeg-*
-    sources:
-      - type: archive
-        url: https://github.com/uclouvain/openjpeg/archive/v2.5.4.tar.gz
-        sha256: a695fbe19c0165f295a8531b1e4e855cd94d0875d2f88ec4b61080677e27188a
 
   - name: libimagequant
     builddir: true
@@ -84,21 +72,6 @@ modules:
       - type: archive
         url: https://github.com/strukturag/libde265/releases/download/v1.0.16/libde265-1.0.16.tar.gz
         sha256: b92beb6b53c346db9a8fae968d686ab706240099cdd5aff87777362d668b0de7
-  - name: libheif
-    cleanup:
-      - /lib/cmake
-      - /share/thumbnailers
-    builddir: true
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DENABLE_PLUGIN_LOADING=OFF
-      - -DWITH_EXAMPLES=OFF
-      - -DWITH_LIBDE265=ON
-      - -DWITH_X265=OFF
-    sources:
-      - type: archive
-        url: https://github.com/strukturag/libheif/releases/download/v1.20.2/libheif-1.20.2.tar.gz
-        sha256: 68ac9084243004e0ef3633f184eeae85d615fe7e4444373a0a21cebccae9d12a
 
   - name: cgif
     builddir: true

--- a/org.tropy.Tropy.yml
+++ b/org.tropy.Tropy.yml
@@ -62,17 +62,6 @@ modules:
         url: https://github.com/randy408/libspng/archive/v0.7.4.tar.gz
         sha256: 47ec02be6c0a6323044600a9221b049f63e1953faf816903e7383d4dc4234487
 
-  - name: libde265
-    config-opts:
-      - --disable-dec265
-      - --disable-sherlock265
-    cleanup:
-      - /bin
-    sources:
-      - type: archive
-        url: https://github.com/strukturag/libde265/releases/download/v1.0.16/libde265-1.0.16.tar.gz
-        sha256: b92beb6b53c346db9a8fae968d686ab706240099cdd5aff87777362d668b0de7
-
   - name: cgif
     builddir: true
     buildsystem: meson


### PR DESCRIPTION
Freedesktop runtime version 25.08 appears to provide the openjpeg and libheif modules.

In most cases, you don't need to build these modules separately, unless your project requires a specific version or a custom configuration.

**Related manifest files**

- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/openjpeg.bst
- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/components/libheif.bst
- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/25.08/elements/include/libheif.yml

---

Fixes: https://github.com/flathub/org.tropy.Tropy/issues/10